### PR TITLE
fix: should add subscribe after hot load

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
+    "dev": "rollup -w --config rollup.config.js",
     "bundle": "rollup --config rollup.config.js",
     "build": "run-s clean bundle",
     "test": "jest",

--- a/src/hooks.spec.tsx
+++ b/src/hooks.spec.tsx
@@ -80,12 +80,17 @@ describe('useSelector', () => {
     const defaultSelector = selector(defaultFn);
     const strictSelector = selector(strictFn, (select, times) => [select(testBox).count, times]);
     const inlineFn = fn((select: Select) => select(testBox).count);
-    const expectCalled = (isDefault: boolean, isStrict: boolean, isInline: boolean) => {
+    const expectCalled = (
+      isDefault: boolean,
+      isStrict: boolean,
+      isInline: boolean,
+      first?: boolean,
+    ) => {
       expect(defaultFn).toBeCalledTimes(isDefault ? 1 : 0);
       defaultFn.mockClear();
-      expect(strictFn).toBeCalledTimes(isStrict ? 1 : 0);
+      expect(strictFn).toBeCalledTimes(isStrict ? (first ? 2 : 1) : 0);
       strictFn.mockClear();
-      expect(inlineFn).toBeCalledTimes(isInline ? 1 : 0);
+      expect(inlineFn).toBeCalledTimes(isInline ? (first ? 2 : 1) : 0);
       inlineFn.mockClear();
     };
     const { result, dispatch, rerender, waitForNextUpdate } = renderUseSelector(
@@ -99,7 +104,7 @@ describe('useSelector', () => {
       { count: 1, test: { count: 1, greets: ['PRELOAD'] } },
       { multiply: 1 },
     );
-    expectCalled(true, true, true);
+    expectCalled(true, true, true, true);
     expect(result.current).toEqual([1, 1, 1, 1]);
     dispatch(addGreet('HELLO'));
     await waitForNextUpdate();

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -3,7 +3,7 @@
  * @author acrazing <joking.young@gmail.com>
  */
 
-import { useContext, useDebugValue, useEffect, useReducer, useRef } from 'react';
+import { useContext, useDebugValue, useLayoutEffect, useReducer, useRef } from 'react';
 import { __Context } from './context';
 import { Selector } from './selector';
 import { Dispatch, Selectable, Snapshot, Store } from './store';
@@ -162,7 +162,7 @@ export function useSelector<Rs extends Selectable[]>(...selectors: Rs): MapSelec
     lastSelector.current = defaultSelectorRef;
     lastStore.current?.disposer();
   }
-  useEffect(() => {
+  useLayoutEffect(() => {
     lastStore.current = {
       store,
       updated: false,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -161,6 +161,8 @@ export function useSelector<Rs extends Selectable[]>(...selectors: Rs): MapSelec
   if (lastStore.current?.store !== store) {
     lastSelector.current = defaultSelectorRef;
     lastStore.current?.disposer();
+  }
+  useEffect(() => {
     lastStore.current = {
       store,
       updated: false,
@@ -200,15 +202,15 @@ export function useSelector<Rs extends Selectable[]>(...selectors: Rs): MapSelec
         }
       }),
     };
-  }
-  useEffect(() => () => lastStore.current?.disposer(), []);
-  if (lastStore.current.error) {
+    return () => lastStore.current?.disposer();
+  }, [store]);
+  if (lastStore.current?.error) {
     const error = lastStore.current.error;
     lastStore.current.error = void 0;
     throw error;
   }
   let selectedState: any;
-  if (lastStore.current.updated) {
+  if (lastStore.current?.updated) {
     lastStore.current.updated = false;
     selectedState = lastSelector.current.results;
   } else {


### PR DESCRIPTION
在hot reload的case 下，组件实例会复用状态，也就是`lastStore` 不再为undefined。也就是当一次hot-reload 发生后，新的useSelector不会再为新的module产物添加订阅。

但是useEffect 的disposer 会执行，导致当前useSelector的订阅被完全移除。

所造成的影响是，后续就会出现dispatch 触发，不会再触发订阅重新执行，组件将每次只执行非update状态下的selector diff。

如果当前selector不是一个factor，而是一个box，那根据这里的[re select](https://github.com/amos-project/amos/blob/c7c2d1e1ae30fe4aaa00156fe5e6dc90dbbf927b/src/hooks.ts#L224)，result可以获得正确的结构。

但是如果当前selector 是一个factor，`selectorChanged` 会判断factor args length长度一致，不再re select，导致result永远只返回热更新前的最后一次的结果