### PR TITLE
Fix QueryResult.isFulfilled bug

### DIFF
--- a/packages/amos-react/src/useQuery.ts
+++ b/packages/amos-react/src/useQuery.ts
@@ -51,7 +51,7 @@ export class QueryResult<R> implements JSONSerializable<QueryResultJSON<R>> {
   }
 
   isFulfilled() {
-    return this.status === 'pending';
+    return this.status === 'fulfilled';
   }
 
   isRejected() {


### PR DESCRIPTION
## Summary
- correct `QueryResult.isFulfilled` to check for `fulfilled` status

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find many types)*

------
https://chatgpt.com/codex/tasks/task_e_6887b114c4b88321a57e9af3e206553e