### PR TITLE
Fix isAnonymous logic and add tests

### DIFF
--- a/packages/amos-testing/src/store/session.boxes.spec.ts
+++ b/packages/amos-testing/src/store/session.boxes.spec.ts
@@ -1,0 +1,13 @@
+import { SessionRecord } from 'amos-testing';
+
+describe('SessionRecord.isAnonymous', () => {
+  it('should return true when user is anonymous', () => {
+    const record = new SessionRecord();
+    expect(record.isAnonymous()).toBe(true);
+  });
+
+  it('should return false when user is logged in', () => {
+    const record = new SessionRecord({ userId: 1 });
+    expect(record.isAnonymous()).toBe(false);
+  });
+});

--- a/packages/amos-testing/src/store/session.boxes.ts
+++ b/packages/amos-testing/src/store/session.boxes.ts
@@ -20,7 +20,7 @@ export class SessionRecord extends Record<SessionModel>({
   userId: 0,
 }) {
   isAnonymous() {
-    return this.userId > 0;
+    return this.userId <= 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- fix `isAnonymous` logic to check for logged out user
- add unit tests for `SessionRecord.isAnonymous`

## Testing
- `yarn test` *(fails: unable to download yarn)*

------
https://chatgpt.com/codex/tasks/task_e_6887b307a04883218918a6d1f5be9a87