### PR TITLE
Update subscribe comment

### DIFF
--- a/packages/amos-core/src/store.ts
+++ b/packages/amos-core/src/store.ts
@@ -53,10 +53,10 @@ export interface Store {
   snapshot: () => Readonly<Snapshot>;
 
   /**
-   * Subscribe the update of the store. The event contains all mutated boxes
-   * and its original state.
+   * Subscribe to store updates.
    *
-   * It only will be fired after the root dispatch completed.
+   * The provided listener is called with no arguments after the root
+   * dispatch has finished processing all mutations.
    */
   subscribe: (fn: () => void) => Unsubscribe;
 


### PR DESCRIPTION
## Summary
- clarify that store subscribers get no arguments and are notified when the root dispatch completes

## Testing
- `yarn test` *(fails: unable to download yarn)*

------
https://chatgpt.com/codex/tasks/task_e_6887b31ba32c8321b4cc34836604b831